### PR TITLE
Add environment variable for disabling TLS verification for use with self-signed certicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This tool is full configured using environment variables.
 - `OIDC_DO_REFRESH`: Whether refresh-token related checks are enabled (don't ask for a refresh token) (default: true)
 - `OIDC_DO_INTROSPECTION`: Whether introspection related checks are enabled (don't call introspection endpoint) (default: true)
 - `OIDC_DO_USER_INFO`: Whether user-info related checks are enabled (don't use userinfo endpoint) (default: true)
+- `OIDC_TLS_VERIFY`: Whether to verify TLS certicates (set to "false" for self-signed) (default: true)
 
 ## Running
 


### PR DESCRIPTION
Hey, saw the messages in https://github.com/BeryJu/oidc-test-client/issues/10 and I can see you've added in OIDC_SCOPES.

I've had a look through the commits I made at the time and the only other option I added was OIDC_TLS_VERIFY. So I've pulled in master and added a new commit for OIDC_TLS_VERIFY.

I haven't tested the new commit as this was originally just an OIDC learning exercise so I no longer have an OIDC provider setup.

If there was any other changes I made that you feel are useful, feel free to copy them (or if you're willing to wait, let me know what else to pull in and I'll get to it when I can). I've moved the original changes to the branch: https://github.com/mdusher/oidc-test-client/tree/mdusher-changes