### PR TITLE
Improve usage of OIDC_TLS_VERIFY

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -68,7 +68,7 @@ func getScopes() []string {
 }
 
 func NewOIDCClient(clientID string, clientSecret string, providerURL string) *OIDCClient {
-	ctx := context.Background()
+	ctx := createContext(context.Background())
 
 	provider, err := oidc.NewProvider(ctx, providerURL)
 	if err != nil {

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -44,7 +44,7 @@ func strToBool(str string) bool {
 
 func skipTLSVerify() bool {
 	tlsVerify := strings.ToLower(Env("OIDC_TLS_VERIFY", "true"))
-	return strToBool(tlsVerify)
+	return !strToBool(tlsVerify)
 }
 
 func createContext(from context.Context) context.Context {


### PR DESCRIPTION
When trying to use the oidc-test-client with an OIDC provider running locally behind a self-signed certificate I ran into two minor issues. Created two small commits to fix those.

* OIDC_TLS_VERIFY had inverted logic
* The configuration didn't apply for the initial requests